### PR TITLE
#17java.lang.reflect.InvocationTargetException例外対応

### DIFF
--- a/fxml/Main.fxml
+++ b/fxml/Main.fxml
@@ -17,7 +17,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="553.0" prefWidth="541.0" style="-fx-background-color: z;" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.MainController">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="553.0" prefWidth="541.0" style="-fx-background-color: z;" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" >
    <children>
       <Button fx:id="AddImcomeButton" layoutX="341.0" layoutY="45.0" mnemonicParsing="false" onAction="#onAddImcomeButtonCliked" prefHeight="43.0" prefWidth="99.0" style="-fx-background-color: #99e07a;" text="＋お小遣い追加" textFill="GREY" />
       <Button fx:id="ImcomesReportButton" layoutX="450.0" layoutY="45.0" mnemonicParsing="false" onAction="#onImcomesReportButtonCliked" prefHeight="43.0" prefWidth="67.0" style="-fx-background-color: #99e07a;" text="       履歴" textFill="#808080" />

--- a/src/controller/Main.java
+++ b/src/controller/Main.java
@@ -13,9 +13,10 @@ public class Main extends Application {
     
     @Override
     public void start(Stage stage) throws Exception {
-    	Parent root = FXMLLoader.load(getClass().getResource("/Main.fxml"));
-        //アプリケーションクラスのstartメソッドでは、FXMLLoad#loadの結果はSceneを作るためにしか使わないのが普通
-    	//ですからFXMLのルートノードが何であれ、常にParentとして扱うのがよい
+    	FXMLLoader loader = new FXMLLoader(getClass().getResource("/Main.fxml"));
+    	loader.setController(new MainController());
+    	Parent root = loader.load();
+    	
         Scene scene = new Scene(root);
         scene.getStylesheets().add(getClass().getResource("/style.css").toExternalForm());
         


### PR DESCRIPTION
作業完了
---
ひとまずアプリ起動直後のエラーには、
java.lang.reflect.InvocationTargetExceptionは表示されなくなった。


考えられる原因
---
#17 で示した3つの仮説いずれも違っていた。

FXMLLoaderがルート要素で fx:controller_属性に遭遇すると、属性で指定されたクラスの引数なしのコンストラクターを（効果的に）呼び出すことにより、そのコントローラーのインスタンスを作成しようとするそうなのだが、MainControllerに引数なしのコンストラクタがない状態のためエラーになっていた模様。

参照サイト

> 
> javafxプログラムの実行時のInvocationTargetException
> https://www.it-swarm-ja.tech/ja/java/javafx%E3%83%97%E3%83%AD%E3%82%B0%E3%83%A9%E3%83%A0%E3%81%AE%E5%AE%9F%E8%A1%8C%E6%99%82%E3%81%AEinvocationtargetexception/10462

対策
---
最も簡単な方法として、FXMLファイルから_fx:controller_属性を削除し、FXMLLoaderでコントローラーを「手動」で設定する。静的なload(...)メソッドに依存する代わりに、FXMLLoaderインスタンスを作成する必要があるため、とのこと。
従って書き換えた。

結果
---
書き換え前はカバレッジもほぼ実行されていなかったが
![カバレッジbefore](https://user-images.githubusercontent.com/73294261/99624777-347a4a00-2a72-11eb-835b-9b77fa16e2e3.PNG)

下記の数値まで改善し、Mainメソッドは86.4％まで実行された。
![カバレッジafter](https://user-images.githubusercontent.com/73294261/99624781-38a66780-2a72-11eb-8f6f-953da3c25d57.PNG)

GUIの表示も可能になったので、issue #17 に対してはOKとする。
その他のエラーは引き続きデバッグを行う。

学んだ事
---

-  カバレッジの利用

-  デバッグで表示されるgraphics.jarへのソースコードの参照先は.zipでも良い。ただし単なる検証作業のひとつで、原因とは無関係。

-  Eclipseのクラスファイル出力先の個別設定方法とフォルダ作成時のネスト回避策（デフォルトPATHを変更してから新規作成する）
