### PR TITLE
#19java.io.FileNotFoundExceptionとjava.sql.SQLExceptionの例外対応

### DIFF
--- a/src/controller/Main.java
+++ b/src/controller/Main.java
@@ -7,7 +7,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
-
+import mysql.MySQLJDBCUtil;
 
 public class Main extends Application {
     
@@ -16,6 +16,8 @@ public class Main extends Application {
     	FXMLLoader loader = new FXMLLoader(getClass().getResource("/Main.fxml"));
     	loader.setController(new MainController());
     	Parent root = loader.load();
+    	//アプリケーションクラスのstartメソッドでは、FXMLLoad#loadの結果はSceneを作るために使う
+    	//FXMLのルートノードが何であれ、常にParentとして扱うのがよい
     	
         Scene scene = new Scene(root);
         scene.getStylesheets().add(getClass().getResource("/style.css").toExternalForm());
@@ -28,10 +30,10 @@ public class Main extends Application {
     public static void main(String[] args) {
         launch(args);
         
-        try(Connection con = mysql.MySQLJDBCUtil.getConnection()) {
+        try(Connection con = MySQLJDBCUtil.getConnection()) {
         	
         	System.out.println(String.format("Connected to database %s "
-        			+ "successfully.", con.getCatalog()));
+        			 + "successfully.", con.getCatalog()));
         } catch(SQLException ex) {
         	ex.printStackTrace();
         }

--- a/src_mysql/mysql/MySQLJDBCUtil.java
+++ b/src_mysql/mysql/MySQLJDBCUtil.java
@@ -1,6 +1,6 @@
 package mysql;
 
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -12,13 +12,12 @@ public class MySQLJDBCUtil {
 	public static Connection getConnection() throws SQLException {
 		Connection con = null;
 
-		try (FileReader f = new FileReader("db.properties")) {
+		try (FileInputStream f = new FileInputStream("/Users/USER/eclipse-workspace/PocketMoney/src_mysql/mysql/db.properties")) {
 			
 			
 			//propertiesファイルのロード
 			Properties pros = new Properties();
 			pros.load(f);
-
 			
 			//データベースパラメータの指定
 			String url    	= pros.getProperty("url");
@@ -30,6 +29,7 @@ public class MySQLJDBCUtil {
 
 		//try-with-resourcesステートメントによる例外処理の簡略化した記述
 		} catch(IOException e) {
+			System.out.println("DBにアクセス出来ません");
 			e.printStackTrace();
 		}
 		return con;

--- a/src_mysql/mysql/db.properties
+++ b/src_mysql/mysql/db.properties
@@ -1,5 +1,5 @@
 # MySQL DB parameters
 
-url = jdbc:mariadb://localhost:3306/DB?
-user = root
-password = root
+url=jdbc:mariadb://localhost:3306/pocketmoney
+user=root
+password=root


### PR DESCRIPTION
#19  作業完了。
　

## エラー`java.io.FileNotFoundException: db.properties`に対して

### 　やったこと

* db.propertiesへの相対パスを絶対パスへ変更
`/Users/USER/eclipse-workspace/PocketMoney/src_mysql/mysql/db.properties`

### 　やらないこと

* 相対パスでの記述

### 　その他

* 色々調べて試みたが正しい相対パスが現時点では分からなかったので、宿題とする。
　
　
　


## エラー`java.sql.SQLException: No suitable driver found for jdbc:mariadb://localhost:3306/DB?`に対して

### 　やったこと

* パス内のdb名を指定していなかったので記述した。`jdbc:mariadb://localhost:3306/pocketmoney`
参照サイト　https://mariadb.com/kb/en/about-mariadb-connector-j/

* 実行構成のCLASSPATHにJDBCドライバ(.jar)が無かった為配置した
参照サイト　https://yukun.info/java-no-suitable-driver-found/

### 　やらないこと

* PreparedStatementmeの実装（別のプルリクで行う）

### 　その他

* 無し
　
　
　

## 学んだこと

* 相対パスへの理解が足りてない（java.nio.file.Pathsクラス等の理解が必要）
* ビルドパス上のクラスパスと、実行構成のクラスパスは違うので注意！
　
　
